### PR TITLE
Add option to open another wallet and several UI fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ buck-out/
 */fastlane/report.xml
 */fastlane/Preview.html
 */fastlane/screenshots
+
+screens/globals.js

--- a/App.js
+++ b/App.js
@@ -92,10 +92,10 @@ const MainDrawerMenu = DrawerNavigator(
             path: '/',
             screen: BackupWallet,
         },
-        // CreateNewWallet : {
-        //     path: '/',
-        //     screen: CreateNewWallet
-        // },
+        CreateNewWallet : {
+            path: '/',
+            screen: CreateNewWallet
+        },
     },
     {
         // initialRouteName: 'Wallet',

--- a/ios/CreateWallet.mm
+++ b/ios/CreateWallet.mm
@@ -200,6 +200,15 @@ RCT_EXPORT_METHOD(openWalletWithHexseed:(NSString* )hexseed callback:(RCTRespons
   
 }
 
+// close the open wallet before creating a new one
+RCT_EXPORT_METHOD(closeWallet: (RCTResponseSenderBlock)callback){
+    // remove all the information saved on the keyChain
+    NSDictionary *spec = @{(__bridge id)kSecClass:(__bridge id)kSecClassGenericPassword};
+    SecItemDelete((__bridge CFDictionaryRef)spec);
+    callback(@[[NSNull null], @"success" ]);
+}
+
+
 @end
 
 

--- a/screens/CompleteSetup.js
+++ b/screens/CompleteSetup.js
@@ -76,7 +76,7 @@ export default class CompleteSetup extends React.Component {
                     <Text style={styles.TextStyleWhite}> START AGAIN </Text>
                   </TouchableOpacity>
 
-                  {this.state.loading ? <ActivityIndicator style={{paddingTop:20}} size={'large'}></ActivityIndicator> : undefined}
+                  {this.state.loading ? <View style={{alignItems:'center'}}><ActivityIndicator style={{paddingTop:20}} size={'large'}></ActivityIndicator><Text style={{color:'white'}}>This may take a while.</Text><Text style={{color:'white'}}>Please be patient...</Text></View> : undefined}
 
               </View>
           </ImageBackground>

--- a/screens/CreateNewWallet.js
+++ b/screens/CreateNewWallet.js
@@ -1,23 +1,113 @@
 import React from 'react';
-import {Text, View, Button, Image} from 'react-native';
+import {Platform, Text, View, Button, Image, StyleSheet, ImageBackground, TouchableOpacity, TouchableHighlight, AsyncStorage} from 'react-native';
+
+import {NativeModules} from 'react-native';
+var IosWallet = NativeModules.CreateWallet;
+var AndroidWallet = NativeModules.AndroidWallet;
 
 export default class CreateNewWallet extends React.Component {
   static navigationOptions = {
     drawerLabel: 'CREATE NEW WALLET',
     drawerIcon: ({ tintColor }) => (
       <Image
-        source={require('../resources/images/wallet_drawer_icon_light.png')} resizeMode={Image.resizeMode.contain} style={{width:30, height:30}}
+        source={require('../resources/images/wallet_drawer_icon_light.png')} resizeMode={Image.resizeMode.contain} style={{width:25, height:25}}
       />
     ),
   };
 
-  render() {
-    return (
-        <View>
-        <Text>below</Text>
-        <Text>Explorer</Text>
-        <Button onPress={()=> this.props.navigation.openDrawer()} title="Open drawer"/>
-        </View>
-    );
+  state={
+      mnemonic: '',
+      hexseed: '',
+      loading: false
   }
+
+  // Get wallet private info
+  closeWallet = () => {
+      // Ios
+      this.setState({loading: true});
+      if (Platform.OS === 'ios'){
+          IosWallet.closeWallet((error, status)=> {
+              if (status == "success") {
+                  // remove the walletCreate item from asyncStorage and redirect to main wallet creation page
+                  this.props.navigation.navigate( 'Auth');
+                  AsyncStorage.removeItem("walletcreated");
+              }
+          });
+      }
+      // Android
+      else {
+          AndroidWallet.sendWalletPrivateInfo((error) => {console.log("ERROR");} , (mnemonic, hexseed)=> {
+              this.setState({loading:false, mnemonic: mnemonic, hexseed: hexseed })
+          });
+      }
+  }
+
+  // render view
+  render() {
+      return (
+          <ImageBackground source={require('../resources/images/sendreceive_bg_half.png')} style={styles.backgroundImage}>
+            <View style={{flex:1}}>
+
+                <View style={{alignItems:'flex-start', justifyContent:'flex-start', paddingTop:40, paddingLeft:30}}>
+                    <TouchableHighlight onPress={()=> this.props.navigation.openDrawer()} underlayColor='white'>
+                      <Image source={require('../resources/images/sandwich.png')} resizeMode={Image.resizeMode.contain} style={{height:25, width:25}} />
+                    </TouchableHighlight>
+                </View>
+                <View style={{ height:130, width:330, borderRadius:10, alignSelf:'center', marginTop: 30}}>
+                    <ImageBackground source={require('../resources/images/backup_bg.png')} imageStyle={{resizeMode: 'contain'}} style={styles.backgroundImage2}>
+                        <View style={{flex:1, alignSelf:'center', width:330, justifyContent:'center', alignItems:'center'}}>
+                            <Text style={{color:'white', fontSize:20}}>OPEN NEW WALLET</Text>
+                        </View>
+                    </ImageBackground>
+                </View>
+                <View style={{flex:1, paddingTop: 50, paddingBottom:100, width:330, alignSelf: 'center',  borderRadius:10}}>
+                    <View style={{height:50, backgroundColor:'white'}}>
+                        <View style={{flex:1, justifyContent:'center', alignItems:'center', backgroundColor:'#fafafa'}}>
+                            <Text>New wallet creation</Text>
+                        </View>
+                    </View>
+                    <View style={{width:'100%',height:1, backgroundColor:'red', alignSelf:'flex-end'}}></View>
+                    <View style={{flex:2, backgroundColor:'white', width:330, padding:30, alignItems:'center'}}>
+                        <View>
+                            <Text>You are about to create a new wallet and close the existing one.</Text>
+                            <TouchableOpacity style={styles.SubmitButtonStyle} activeOpacity = { .5 } onPress={ this.closeWallet }>
+                                <Text style={styles.TextStyle}> CREATE </Text>
+                            </TouchableOpacity>
+                        </View>
+                    </View>
+                </View>
+            </View>
+        </ImageBackground>
+      );
+  }
+
 }
+
+
+const styles = StyleSheet.create({
+    SubmitButtonStyle: {
+        alignSelf:'center',
+        width: 150,
+        marginTop:30,
+        paddingTop:15,
+        paddingBottom:15,
+        backgroundColor:'#f33160',
+        borderWidth: 1,
+        borderColor: '#fff'
+    },
+    TextStyle:{
+        color:'#fff',
+        textAlign:'center',
+    },
+    backgroundImage: {
+        flex: 1,
+        width: null,
+        height: null,
+    },
+    backgroundImage2: {
+        alignSelf: 'flex-start',
+        left: 0
+    },
+
+
+});

--- a/screens/CreateWalletTreeHeight.js
+++ b/screens/CreateWalletTreeHeight.js
@@ -70,8 +70,10 @@ export default class CreateWalletTreeHeight extends React.Component {
                   <Text>SET UP YOUR WALLET</Text>
                   <Text style={styles.bigTitle}>TREE HEIGHT</Text>
                   <View style={{width:100, height:1, backgroundColor:'white', marginTop:30,marginBottom:20}}></View>
-                  <Text style={{color:'white'}}>Important: Once you run out of signatures you</Text>
-                  <Text style={{color:'white'}}>will need to create a new wallet</Text>
+                  <Text style={{color:'white'}}><Text style={{textDecorationLine:'underline'}}>Important:</Text> Once you run out of signatures you</Text>
+                  <Text style={{color:'white'}}>will need to create a new wallet.</Text>
+                  <Text style={{color:'white'}}>Be aware that wallet creation time increases</Text>
+                  <Text style={{color:'white'}}>with wallet height.</Text>
 
                   {Platform.OS === 'ios' ?
 

--- a/screens/OpenExistingWallet.js
+++ b/screens/OpenExistingWallet.js
@@ -25,11 +25,13 @@ var IosWallet = NativeModules.CreateWallet;
 // android
 var AndroidWallet = NativeModules.AndroidWallet;
 
+var GLOBALS = require('./globals');
+
 export default class OpenExistingWallet extends React.Component {
 
     state={
-        hexseed: '01050025f6c0b547c4231721f71c90176b6ee20b2aeff81f81773e099f2d9625e8045cba8aa504bdade1b6e5e3e05d9264e8d3',
-        // hexseed: '',
+        hexseed: GLOBALS.hexseed,
+        // hexseed : "",
         isLoading: false
     }
 
@@ -77,6 +79,7 @@ export default class OpenExistingWallet extends React.Component {
   }
 
   render() {
+      console.log("HEXSEED IS: ", this.state.hexseed)
       return (
           <KeyboardAvoidingView behavior="padding" style={{flex:1}}>
           <ImageBackground source={require('../resources/images/signin_process_bg.png')} style={styles.backgroundImage}>

--- a/screens/SendReceive.js
+++ b/screens/SendReceive.js
@@ -16,6 +16,8 @@ var IosWallet = NativeModules.refreshWallet;
 // android
 var AndroidWallet = NativeModules.AndroidWallet;
 
+var GLOBALS = require('./globals');
+
 export default class SendReceive extends React.Component {
   static navigationOptions = {
     drawerLabel: 'SEND & RECEIVE',
@@ -26,13 +28,14 @@ export default class SendReceive extends React.Component {
     ),
   };
 
+
+
   componentDidMount() {
 
       const recipient = this.props.navigation.getParam('recipient', 'norecipient');
       if (recipient == "norecipient"){
           // this.setState({recipient:""})
-          // this.setState({recipient:"Q0105003e32fcbcdcaf09485272f1aa1c1e318daaa8cf7cd03bacf7cfceeddf936bb88efe1e4d21"})
-
+          this.setState({recipient: GLOBALS.recipient })
       }
       else {
           this.setState({recipient:recipient})
@@ -57,13 +60,13 @@ export default class SendReceive extends React.Component {
               }
           }
           IosWallet.refreshWallet((error, walletAddress, otsIndex, balance, keys)=> {
-              this.setState({walletAddress: walletAddress, balance: balance, otsIndex: otsIndex, isLoading:false})
+              this.setState({walletAddress: walletAddress, balance: balance/ 1000000000, otsIndex: otsIndex, isLoading:false})
           });
       }
       // Android
       else {
           AndroidWallet.refreshWallet( (err) => {console.log(err);}, (walletAddress, otsIndex, balance, keys)=> {
-              this.setState({walletAddress: walletAddress, balance: balance, otsIndex: otsIndex, isLoading:false})
+              this.setState({walletAddress: walletAddress, balance: balance/ 1000000000, otsIndex: otsIndex, isLoading:false})
           });
       }
   }
@@ -71,6 +74,7 @@ export default class SendReceive extends React.Component {
 
   state={
       // amount: "10",
+      balance: "loading...",
       view: 'send',
       fee: "0.001"
   }
@@ -137,7 +141,6 @@ export default class SendReceive extends React.Component {
                             Alert.alert( "PENDING TRANSACTION IDENTIFIED"  , "You have a pending transaction on the network. Please check your OTS index again as it might need to be adjusted manually." , [{text: "OK", onPress: () => this.props.navigation.navigate('SendReceive') } ] )
                         }
                     });
-
                 }
             }
             else {
@@ -160,7 +163,7 @@ export default class SendReceive extends React.Component {
                         <View style={{ alignItems:'center', paddingTop:this.state.paddingTopMain }}>
                             <ImageBackground source={require('../resources/images/fund_bg_small.png')} resizeMode={Image.resizeMode.contain} style={{height:100, width:330, justifyContent:'center',alignItems:'center'}} >
                             <Text style={{color:'white'}}>QRL BALANCE</Text>
-                            <Text style={{color:'white',fontSize:30}}>{this.state.balance / 1000000000 }</Text>
+                            <Text style={{color:'white',fontSize:30}}>{this.state.balance}</Text>
                             </ImageBackground>
                             <TouchableOpacity style={styles.SubmitButtonStyle2} activeOpacity = { .5 } onPress={ this.refreshWallet }>
                                 <Image source={require("../resources/images/refresh.png")} style={{height:40, width:40}}/>
@@ -226,7 +229,6 @@ export default class SendReceive extends React.Component {
                             </View>
                         </View>
                     }
-
             </ImageBackground>
           );
       }
@@ -244,7 +246,7 @@ export default class SendReceive extends React.Component {
                         <View style={{ alignItems:'center', paddingTop:20}}>
                             <ImageBackground source={require('../resources/images/fund_bg_small.png')} resizeMode={Image.resizeMode.contain} style={{height:100, width:330, justifyContent:'center',alignItems:'center'}} >
                             <Text style={{color:'white'}}>QRL BALANCE</Text>
-                            <Text style={{color:'white',fontSize:30}}>{this.state.balance / 1000000000 }</Text>
+                            <Text style={{color:'white',fontSize:30}}>{this.state.balance}</Text>
                             </ImageBackground>
                             <TouchableOpacity style={styles.SubmitButtonStyle2} activeOpacity = { .5 } onPress={ this.refreshWallet }>
                                 <Image source={require("../resources/images/refresh.png")} style={{height:40, width:40}}/>

--- a/screens/TransactionsHistory.js
+++ b/screens/TransactionsHistory.js
@@ -157,7 +157,6 @@ export default class Wallet extends React.Component{
     }
 
     render() {
-        console.log("LOADING TX HISTORY MAINVIEW...")
         if (this.state.isLoading) {
             return (
                 <ImageBackground source={require('../resources/images/main_bg_half.png')} style={styles.backgroundImage}>
@@ -176,10 +175,10 @@ export default class Wallet extends React.Component{
                </View>
 
                <View style={{ alignItems:'center',flex:1}}>
-                   <ImageBackground source={require('../resources/images/fund_bg.png')} resizeMode={Image.resizeMode.contain} style={{height:240, width:330, justifyContent:'center',alignItems:'center'}} >
+                   <ImageBackground source={require('../resources/images/fund_bg.png')} resizeMode={Image.resizeMode.contain} style={{height:240, width:330, justifyContent:'center',alignItems:'center', paddingTop: 30}} >
                        <Text style={{color:'white'}}>QRL BALANCE</Text>
-                       <Text style={{color:'white',fontSize:30}}>{this.state.balance / 1000000000 }</Text>
-
+                       <Text style={{color:'white',fontSize:30}}>0</Text>
+                       <Text style={{color:'white',fontSize:13}}>USD $0</Text>
                        <View style={{width:"80%", borderRadius:10, flexDirection:'row', paddingTop:30,paddingBottom:5}}>
                            <View style={{flex:1}}><Text style={{fontSize:12, color:"white"}}>MARKET CAP</Text></View>
                            <View style={{flex:1, justifyContent:'center', alignItems:'center'}}><Text style={{fontSize:12, color:"white"}}>PRICE</Text></View>
@@ -190,6 +189,10 @@ export default class Wallet extends React.Component{
                            <View style={{flex:1, justifyContent:'center'}}><Text style={{fontSize:12, color:"white"}}>NA</Text></View>
                            <View style={{flex:1, alignItems:'center', justifyContent:'center'}}><Text style={{fontSize:12, color:"white"}}>NA</Text></View>
                            <View style={{flex:1, justifyContent:'center'}}><Text style={{fontSize:12, color:"white"}}>NA</Text></View>
+                       </View>
+
+                       <View style={{alignSelf:'flex-end', right:23}}>
+                           <Text style={{color:'white',fontSize:10}}>Powered by COINLIB</Text>
                        </View>
 
                        <TouchableOpacity style={styles.SubmitButtonStyle2} activeOpacity = { .5 } onPress={ this.refreshWallet }>


### PR DESCRIPTION
- user can open a new wallet from within the app (by closing the actual one)
- clean the tx history view while it is loading the required information
- let user know that wallet creation time increases with tree height
- add text "this may take a while..." during wallet creation, in addition to spinner
- correct SendReceive view that aas showing NaN for the balance until the correct balance is fetched (-> change to "loading...")
- add a hardcoded recipient address to easily test the send option without manually entering a QRL wallet address